### PR TITLE
Generate a job url from the current tab

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -77,3 +77,7 @@ body {
         opacity: 0.5;
     }
 }
+
+.input-group {
+  width: 100%;
+}

--- a/js/options.js
+++ b/js/options.js
@@ -36,10 +36,12 @@
   var refreshTimeSpan = document.getElementById('refreshTimeSpan');
   var optionsStatusElement = document.getElementById('optionStatus');
   var urlsStatusElement = document.getElementById('urlsStatus');
+  var generateUrlRule = document.getElementById('generateUrlRule');
 
   var defaultOptions = {
     refreshTime: 60,
-    notification: 'all'
+    notification: 'all',
+    generateUrlRule: ''
   };
 
   function showSavedNotification(statusElement) {
@@ -58,7 +60,8 @@
   function saveOptions() {
     var options = {
       refreshTime: refreshTimeInput.value,
-      notification: document.querySelector('[name=notification]:checked').value
+      notification: document.querySelector('[name=notification]:checked').value,
+      generateUrlRule: generateUrlRule.value
     };
     chrome.storage.local.set({options: options}, function () {
       showSavedNotification(optionsStatusElement);
@@ -82,6 +85,7 @@
       document.querySelector('[name=notification]:checked').checked = false;
       document.querySelector('[name=notification][value="' + options.notification + '"]').checked = true;
       refreshTimeSpan.textContent = refreshTimeInput.value = options.refreshTime;
+      generateUrlRule.value = options.generateUrlRule;
     });
   }
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "description": "This extension notifies you on Jenkins build results.",
   "author": "Guillaume Girou",
   "homepage_url": "https://github.com/ggirou/yet-another-jenkins-notifier",
-  "version": "2.3.1",
+  "version": "2.4",
   "applications": {
     "gecko": {
       "id": "yet-another-jenkins-notifier@guillaume.girou",
@@ -34,6 +34,7 @@
   "permissions": [
     "<all_urls>",
     "storage",
-    "notifications"
+    "notifications",
+    "activeTab"
   ]
 }

--- a/options.html
+++ b/options.html
@@ -52,6 +52,18 @@
   <button id="saveUrls" type="submit">Save urls</button>
 </fieldset>
 <p style="visibility: hidden" id="urlsStatus">Urls saved.</p>
+<fieldset>
+  <legend>Genrerate url with macro from the current tab</legend>
+  <p>Availible macros</p>
+  <ul>
+    <li><em>branchName</em> (Github PR)</li>
+    <li><em>repoName</em> (Github PR)</li>
+  </ul>
+  <input style="width: 100%" id="generateUrlRule"/>
+  <p>
+    Example: <em>https://jenkins.example.com/{{repoName}}/job/{{branchName}}</em>
+  </p>
+</fieldset>
 
 <script src="js/services.js"></script>
 <script src="js/options.js"></script>

--- a/popup.html
+++ b/popup.html
@@ -73,18 +73,26 @@
   </template>
 </main>
 <footer>
-  <form id="urlForm" name="urlForm">
-    <div class="input-group">
-      <label class="input-group-addon" for="url">Url</label>
-      <input type="url" class="form-control" id="url" name="url"
-             autofocus tabindex="1" required>
-      <span class="input-group-btn">
+  <div class="input-group">
+    <form id="urlForm" name="urlForm">
+      <div class="input-group">
+        <label class="input-group-addon" for="url">Url</label>
+        <input type="url" class="form-control" id="url" name="url"
+               autofocus tabindex="1" required>
+        <span class="input-group-btn">
           <button id="addButton" type="submit" class="btn btn-primary">
             <span class="glyphicon glyphicon-plus"></span>
           </button>
         </span>
-    </div>
-    <div id="errorMessage" class="help-block"></div>
+      </div>
+    </form>
+    <span class="input-group-btn">
+      <button id="linkGeneratorButton" class="btn btn-warning">
+        <span class="glyphicon glyphicon-link"></span>
+      </button>
+    </span>
+  </div>
+  <div id="errorMessage" class="help-block"></div>
     <div class="help-block">
       Examples:
       <dl class="dl-horizontal">
@@ -100,7 +108,6 @@
         <dd>http://jenkins/</dd>
       </dl>
     </div>
-  </form>
 </footer>
 </body>
 </html>


### PR DESCRIPTION
### Why this Pull request
To speed up my development flow, I added a functionality to automatically generate a job url from the current browser.

### The idea
For my need, the build I when to watch correspond to my open pull request on Github and with the page dom I can easily generate the build url.

### The implementation
So, I create a field in the options to set the pattern of the build url.
With a system of macros, (currently limited for my personal need, but can be easily be improve) the generator button will take the dom of the current tab, apply a regex to get the value of the macro, apply the rule set in the option and return the url.

A [build](https://github.com/Bhacaz/yet-another-jenkins-notifier/releases/tag/v2.4) is available on my fork if any one want to try it.

--- 

<img src="https://user-images.githubusercontent.com/7858787/55628384-90e60400-577e-11e9-9c2c-29d4d02a89bd.png" width="300" />
<img src="https://user-images.githubusercontent.com/7858787/55628391-980d1200-577e-11e9-9cbf-9782e8b6fda7.png" width="500" />


